### PR TITLE
v3.0.2: chore: update babel-plugin-transform-class-inject-directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "aurelia-path": "^1.1.5",
 
     "webpack": "^4.42.1",
-    "babel-plugin-transform-class-inject-directive": "^3.0.1"
+    "babel-plugin-transform-class-inject-directive": "^3.0.2"
   },
   "devDependencies": {
     "wootils": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,10 +1701,10 @@ babel-plugin-jest-hoist@^25.2.6:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-transform-class-inject-directive@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-inject-directive/-/babel-plugin-transform-class-inject-directive-3.0.1.tgz#f7adb91dd9842f8ab924c8e3b54e99e6cdf72aa5"
-  integrity sha512-BSiJHeUkPygbi3mmYvQdj8CszhI9yyrJECcmwNZC7UZ6OPrqmhCJb+absWfyKeN/IfkLZ5hEzQrmaLMIgTwAlw==
+babel-plugin-transform-class-inject-directive@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-inject-directive/-/babel-plugin-transform-class-inject-directive-3.0.2.tgz#805d28449498c9f22bfb51d9b3980848e9f0909d"
+  integrity sha512-5L04eW5LNu9J89bu6ClHU1CoLFBm3NR9JHsqOipcz4i359Wwnq3OZDYKWT3t0506KWishINZAfrguIEV3f8Fog==
   dependencies:
     "@babel/types" "7.9.5"
 
@@ -2831,9 +2831,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.3.390:
-  version "1.3.403"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.403.tgz#c8bab4e2e72bf78bc28bad1cc355c061f9cc1918"
-  integrity sha512-JaoxV4RzdBAZOnsF4dAlZ2ijJW72MbqO5lNfOBHUWiBQl3Rwe+mk2RCUMrRI3rSClLJ8HSNQNqcry12H+0ZjFw==
+  version "1.3.405"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.405.tgz#b84fcb157edb26eae6c36d93d416cb51caa399bd"
+  integrity sha512-D+xkP+hAQY/790DzImC8bI8QJLaArNG4b74bYvkhkK/fli51JmNyUYxwKLSl/8VPGkkXEqKCupSDD05/E5P72w==
 
 elliptic@^6.0.0:
   version "6.5.2"
@@ -3241,9 +3241,9 @@ esprima@~3.1.0:
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
 esquery@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.2.0.tgz#a010a519c0288f2530b3404124bfb5f02e9797fe"
-  integrity sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.2.1.tgz#105239e215c5aa480369c7794d74b8b5914c19d4"
+  integrity sha512-/IcAXa9GWOX9BUIb/Tz2QrrAWFWzWGrFIeLeMRwtiuwg9qTFhSYemsi9DixwrFFqVbhBZ47vGcxEnu5mbPqbig==
   dependencies:
     estraverse "^5.0.0"
 


### PR DESCRIPTION
### What does this PR do?

Follow up for #10 - `babel-plugin-transform-class-inject-directive` had a bug and caused the code to become invalid when used with decorators... something that Aurelia heavily relies on.

I fixed the plugin, made a release and I'm updating the lock of this project to use the new version.

### How should it be tested manually?

Try the `inject` directive on a class where you use `@bindable` or another decorator; with `3.0.1` you should get an error, but it should be fixed on this branch.